### PR TITLE
Remove pipeline folder spec from BaseClasses

### DIFF
--- a/baseclasses/CMakeLists.txt
+++ b/baseclasses/CMakeLists.txt
@@ -79,7 +79,6 @@ target_include_directories(
   "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(BaseClasses Winmm)
-set_property(TARGET BaseClasses PROPERTY FOLDER "Pipeline")
 set_property(TARGET BaseClasses PROPERTY ARCHIVE_OUTPUT_NAME_DEBUG "BaseClassesd")
 install(TARGETS BaseClasses EXPORT BaseClassesTargets
   DESTINATION lib


### PR DESCRIPTION
Relic from when this file was part of platform, minor fix.
